### PR TITLE
Change default model docs from COVIDNET to COVIDNet-CXR4-B

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Arguments
     If specified, print version number and exit.
 
     [--modelname]
-    The name of the model being used, this is optional (default is COVIDNET).
+    The name of the model being used, this is optional (default is COVIDNet-CXR4-B).
 
     [--imagefile]
     The name of the input image in the input directory, this is required

--- a/grad_cam/grad_cam.py
+++ b/grad_cam/grad_cam.py
@@ -80,7 +80,7 @@ where necessary.)
         If specified, print version number and exit.
 
         [--modelname]
-        The name of the model being used, this is optional (default is COVIDNET).
+        The name of the model being used, this is optional (default is COVIDNet-CXR4-B).
 
         [--imagefile]
         The name of the input image in the input directory, this is required


### PR DESCRIPTION
In the README and within the grad_cam config file, the parameter
modelname currently has a default of COVIDNET, when it should actually
reflect the particular model of COVIDNET we're using, which is
COVIDNet-CXR4-B.